### PR TITLE
Set the language version to C# 5

### DIFF
--- a/Rackspace.VisualStudio.CloudExplorer/Rackspace.VisualStudio.CloudExplorer.11.csproj
+++ b/Rackspace.VisualStudio.CloudExplorer/Rackspace.VisualStudio.CloudExplorer.11.csproj
@@ -48,6 +48,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Rackspace.VisualStudio.CloudExplorer/Rackspace.VisualStudio.CloudExplorer.12.csproj
+++ b/Rackspace.VisualStudio.CloudExplorer/Rackspace.VisualStudio.CloudExplorer.12.csproj
@@ -48,6 +48,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Rackspace.VisualStudio.CloudExplorer/Rackspace.VisualStudio.CloudExplorer.14.csproj
+++ b/Rackspace.VisualStudio.CloudExplorer/Rackspace.VisualStudio.CloudExplorer.14.csproj
@@ -48,6 +48,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
This change ensures developers working in Visual Studio 2015 won't accidentally use features which were added in C# 6 (which would break development and testing compatibility with Visual Studio 2012 and 2013).